### PR TITLE
Cleaning up javadoc dependency.

### DIFF
--- a/rest-compress-lib/pom.xml
+++ b/rest-compress-lib/pom.xml
@@ -62,12 +62,6 @@
             <version>1.0.0</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9</version>
-        </dependency>
-
         <!-- Below are needed for Interceptor for LZF
         Versions taken from here:  http://repo1.maven.org/maven2/org/jboss/as/jboss-as-parent/7.2.0.Final/jboss-as-parent-7.2.0.Final.pom
             Version is: version.org.jboss.resteasy
@@ -90,21 +84,37 @@
         </repository>
     </distributionManagement>
 
+    <profiles>
+        <profile>
+            <id>java8-disable-strict-javadoc</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <!-- none: disables doclint -->
+                <javadoc.doclint.none>-Xdoclint:none</javadoc.doclint.none>
+            </properties>
+        </profile>
+    </profiles>
+
     <!-- Below is needed to coax GPG signing of javadocs/sources -->
     <build>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-                <source>1.7</source>
-                <target>1.7</target>
-            </configuration>
-        </plugin>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
+                <version>2.10.3</version>
+                <configuration>
+                    <additionalparam>${javadoc.doclint.none}</additionalparam>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Didn't need the javadoc plugin as a dependency.
Version of plugin increased, 2.9 depended on version of jackrabbit with CVE-2015-1833 (https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-1833)
Added update for java 1.8 to disable lint.  Should work still with java 1.7.
